### PR TITLE
Fix vscode launch.json and tasks.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,9 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/src/bin/Debug/net5.0/calvin.dll",
+            "program": "${workspaceFolder:calvin}/src/bin/Debug/netcoreapp5.0/calvin.service.dll",
             "args": [],
-            "cwd": "${workspaceFolder}/src",
+            "cwd": "${workspaceFolder:calvin}/src",
             "stopAtEntry": false,
             "console": "internalConsole"
         },
@@ -22,9 +22,9 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/src/bin/Debug/net5.0/calvin.dll",
+            "program": "${workspaceFolder:calvin}/src/bin/Debug/netcoreapp5.0/calvin.service.dll",
             "args": [],
-            "cwd": "${workspaceFolder}/src",
+            "cwd": "${workspaceFolder:calvin}/src",
             "stopAtEntry": false,
             "serverReadyAction": {
                 "action": "openExternally",
@@ -34,7 +34,7 @@
                 "ASPNETCORE_ENVIRONMENT": "Development"
             },
             "sourceFileMap": {
-                "/Views": "${workspaceFolder}/Views"
+                "/Views": "${workspaceFolder:calvin}/Views"
             }
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
             "label": "clean",
             "command": "dotnet",
             "type": "shell",
-            "options": {"cwd": "/Users/Rune/Projects/calvin/src"},
+            "options": {"cwd": "${workspaceFolder:calvin}/src"},
             "args": [
                 "clean",
                 "/consoleloggerparameters:NoSummary"
@@ -23,7 +23,7 @@
             "label": "build",
             "command": "dotnet",
             "type": "shell",
-            "options": {"cwd": "/Users/Rune/Projects/calvin/src"},
+            "options": {"cwd": "${workspaceFolder:calvin}/src"},
             "args": [
                 "build",
                 // Ask dotnet build to generate full paths for file names.


### PR DESCRIPTION
Removes hardcoded path to project folder, changes program folder from `net5.0` to `netcoreapp5.0` and makes `workspaceFolder` reference specific project.