### PR TITLE
Add graphql-playground and limit graphql routes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,9 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/src/bin/Debug/net5.0/calvin.dll",
+            "program": "${workspaceFolder:calvin}/src/bin/Debug/netcoreapp5.0/calvin.service.dll",
             "args": [],
-            "cwd": "${workspaceFolder}/src",
+            "cwd": "${workspaceFolder:calvin}/src",
             "stopAtEntry": false,
             "console": "internalConsole"
         },
@@ -22,9 +22,9 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/src/bin/Debug/net5.0/calvin.dll",
+            "program": "${workspaceFolder:calvin}/src/bin/Debug/netcoreapp5.0/calvin.service.dll",
             "args": [],
-            "cwd": "${workspaceFolder}/src",
+            "cwd": "${workspaceFolder:calvin}/src",
             "stopAtEntry": false,
             "serverReadyAction": {
                 "action": "openExternally",
@@ -34,7 +34,7 @@
                 "ASPNETCORE_ENVIRONMENT": "Development"
             },
             "sourceFileMap": {
-                "/Views": "${workspaceFolder}/Views"
+                "/Views": "${workspaceFolder:calvin}/Views"
             }
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
             "label": "clean",
             "command": "dotnet",
             "type": "shell",
-            "options": {"cwd": "/Users/Rune/Projects/calvin/src"},
+            "options": {"cwd": "${workspaceFolder:calvin}/src"},
             "args": [
                 "clean",
                 "/consoleloggerparameters:NoSummary"
@@ -23,7 +23,7 @@
             "label": "build",
             "command": "dotnet",
             "type": "shell",
-            "options": {"cwd": "/Users/Rune/Projects/calvin/src"},
+            "options": {"cwd": "${workspaceFolder:calvin}/src"},
             "args": [
                 "build",
                 // Ask dotnet build to generate full paths for file names.

--- a/src/HttpHandlers.fs
+++ b/src/HttpHandlers.fs
@@ -28,6 +28,9 @@ module HttpHandlers =
     let setContentTypeAsJson : HttpHandler =
         setHttpHeader "Content-Type" "application/json"
 
+    let setContentTypeAsHtml : HttpHandler =
+        setHttpHeader "Content-Type" "application/html"
+
     let private graphQL (next : HttpFunc) (ctx : HttpContext) = task {
         let serialize d = JsonConvert.SerializeObject(d, jsonSettings)
 
@@ -106,7 +109,17 @@ module HttpHandlers =
             return! okWithStr (json result) next ctx
     }
 
-    let webApp : HttpHandler = 
+    let webApp : HttpHandler =
         setCorsHeaders
-        >=> graphQL 
-        >=> setContentTypeAsJson
+        >=> choose [
+            GET >=> 
+                choose [
+                    route "/graphql"
+                    >=> htmlFile "static/playground.html"
+                    >=> setContentTypeAsHtml ]
+            POST >=> 
+                choose [
+                    route "/graphql"
+                    >=> graphQL
+                    >=> setContentTypeAsJson ]
+        ]

--- a/src/Startup.fs
+++ b/src/Startup.fs
@@ -26,7 +26,7 @@ type Startup private () =
         app
             .UseGiraffeErrorHandler(errorHandler)
             .UseWebSockets()
-            .UseMiddleware<GraphQLWebSocketMiddleware<Root>>(Schema.executor, fun () -> { RequestId = Guid.NewGuid().ToString() })
+            //.UseMiddleware<GraphQLWebSocketMiddleware<Root>>(Schema.executor, fun () -> { RequestId = Guid.NewGuid().ToString() })
             .UseGiraffe HttpHandlers.webApp
 
     member val Configuration : IConfiguration = null with get, set

--- a/src/static/playground.html
+++ b/src/static/playground.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<!--
+    License: MIT
+    Source: https://github.com/graphql/graphql-playground/blob/master/packages/graphql-playground-html/minimal.html
+-->
+<head>
+  <meta charset=utf-8/>
+  <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
+  <title>GraphQL Playground</title>
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
+  <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
+  <script src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
+</head>
+
+<body>
+  <div id="root">
+    <style>
+      body {
+        background-color: rgb(23, 42, 58);
+        font-family: Open Sans, sans-serif;
+        height: 90vh;
+      }
+
+      #root {
+        height: 100%;
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .loading {
+        font-size: 32px;
+        font-weight: 200;
+        color: rgba(255, 255, 255, .6);
+        margin-left: 20px;
+      }
+
+      img {
+        width: 78px;
+        height: 78px;
+      }
+
+      .title {
+        font-weight: 400;
+      }
+    </style>
+    <img src='//cdn.jsdelivr.net/npm/graphql-playground-react/build/logo.png' alt=''>
+    <div class="loading"> Loading
+      <span class="title">GraphQL Playground</span>
+    </div>
+  </div>
+  <script>window.addEventListener('load', function (event) {
+      GraphQLPlayground.init(document.getElementById('root'), {
+        // options as 'endpoint' belong here
+        shareEnabled: true,
+        settings: {
+            'request.credentials': 'same-origin',
+        },
+      })
+    })</script>
+</body>
+
+</html>


### PR DESCRIPTION
A POST to /graphql will trigger the graphQL handler and a GET will return the playground for browser use.

Also disables websockets becuase some odd race-condition-like bug causes HTTP requests to return empty responses.